### PR TITLE
Fix order of HTML escapes

### DIFF
--- a/main.js
+++ b/main.js
@@ -292,9 +292,9 @@ Deno.serve({
               return;
             }
             const sanitizedPost = data.p
+              .replace(/&/g, "&amp;")
               .replace(/</g, "&lt;")
               .replace(/>/g, "&gt;")
-              .replace(/&/g, "&amp;")
               .replace(/"/g, "&quot;")
               .replace(/'/g, "&#x27;")
               .replace(/\//g, "&#x2F;")


### PR DESCRIPTION
Fixes `<` and `>` being turned into `&amp;lt;` and `&amp;gt;`, untested but should work